### PR TITLE
Support CEREBRO_PORT environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,10 @@ RUN  apt-get update \
  && adduser -gid 1000 -uid 1000 cerebro \
  && chown -R cerebro:cerebro /opt/cerebro
 
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
+
 WORKDIR /opt/cerebro
-EXPOSE 9000
 USER cerebro
-ENTRYPOINT [ "/opt/cerebro/bin/cerebro" ]
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ For using a specific version run:
 ```
 docker run -p 9000:9000 lmenezes/cerebro:0.8.3
 ```
+
+### Configuration
+
+You can configure a custom port for cerebro by using the `CEREBRO_PORT` environment variable. This defaults to `9000`.
+
+**Example**
+
+docker run -e CEREBRO_PORT=8080 -p 8080:8080 lmenezes/cerebro

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/opt/cerebro/bin/cerebro -Dhttp.port="${CEREBRO_PORT:-9000}"


### PR DESCRIPTION
As per my issue [here](https://github.com/lmenezes/cerebro-docker/issues/4), I'd like to be able to change the cerebro port at runtime.

This would allow the use of cerebro within a Kubernetes cluster without port clashes. This is quite common for docker containers.

I've made some changes to the Dockerfile to swap to using an `entrypoint.sh` file which reads from the environment variable `CEREBRO_PORT` - this will default to 9000 if not specified (so it remains compatible).

I don't see any compatibility breakages here, my _slight_ concern is dropping the `EXPOSE` command in the Dockerfile - but as this is optional (and the existing instructions get the user to specify this manually), I believe it's superfluous.