### PR TITLE
Upgrade to jdk 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim as builder
+FROM openjdk:21-slim as builder
 
 ARG CEREBRO_VERSION=0.9.4
 
@@ -9,7 +9,7 @@ RUN  apt-get update \
   | tar xzv --strip-components 1 -C /opt/cerebro \
  && sed -i '/<appender-ref ref="FILE"\/>/d' /opt/cerebro/conf/logback.xml
 
-FROM openjdk:11-jre-slim
+FROM openjdk:21-slim
 
 COPY --from=builder /opt/cerebro /opt/cerebro
 
@@ -21,5 +21,8 @@ RUN addgroup -gid 1000 cerebro \
 
 WORKDIR /opt/cerebro
 USER cerebro
+
+# At least with Cerebro 0.9.4 some JVM options are required to run on openjdk 16+. See https://github.com/lmenezes/cerebro/issues/514
+ENV JAVA_OPTS "--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.net.www.protocol.file=ALL-UNNAMED"
 
 ENTRYPOINT [ "/opt/cerebro/bin/cerebro" ]


### PR DESCRIPTION
The version of openjdk currently in use is pretty old. I suggest to upgrade to a recent version to benefit from the improvements of the JVM and the latest security patches of the base image.